### PR TITLE
Update c_init error message

### DIFF
--- a/common/.local/bin/c_init
+++ b/common/.local/bin/c_init
@@ -5,7 +5,7 @@ usage() {
 }
 
 if [[ -z "$1" || -d "$1" ]]; then
-    echo "The name of the project is empty or already exist on the current directory"
+    echo "The name of the project is empty or already exists in the current directory"
     usage
     exit 1
 else


### PR DESCRIPTION
## Summary
- correct grammar in `c_init` error message

## Testing
- `shellcheck common/.local/bin/c_init` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2092adfc8329bc92a2ab3e0b0bbb