### PR TITLE
Fix invalid filename message in copy script

### DIFF
--- a/common/.local/bin/copy
+++ b/common/.local/bin/copy
@@ -14,7 +14,7 @@ elif [ $# -gt 0 ]; then
     if [ -f "$1" ]; then
         value=$(cat "$1")
     else
-        echo "Error: $file is not a valid file."
+        echo "Error: $1 is not a valid file."
         usage
         exit 1
     fi


### PR DESCRIPTION
## Summary
- display the bad filename in the `copy` helper script
- run shell syntax validation

## Testing
- `bash -n common/.local/bin/copy`
- `shellcheck common/.local/bin/copy` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685f2095154883298dd4c67c1d6bcc7c